### PR TITLE
21-server-can-broadcast-messages into main

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,18 @@ struct user {
 
 struct user users[MAX_USERS];
 
+void broadcast_server_message(const char* message) {
+    pthread_mutex_lock(&clients_mutex);
+
+    for (int i = 0; i < num_clients; i++) {
+        if (send(users[i].clientSocket, message, strlen(message), 0) < 0) {
+            perror("Server broadcast failed");
+        }
+    }
+
+    pthread_mutex_unlock(&clients_mutex);
+}
+
 int main() {
     int server_fd;
     int new_socket;

--- a/src/main.c
+++ b/src/main.c
@@ -28,32 +28,6 @@ struct user {
 
 struct user users[MAX_USERS];
 
-void broadcast_server_message(const char* message) {
-    pthread_mutex_lock(&clients_mutex);
-
-    for (int i = 0; i < num_clients; i++) {
-        if (send(users[i].clientSocket, message, strlen(message), 0) < 0) {
-            perror("Server broadcast failed");
-        }
-    }
-
-    pthread_mutex_unlock(&clients_mutex);
-}
-
-void *handle_server_commands(void *arg) {
-    char buffer[BUFFER_SIZE];
-    while (1) {
-        fgets(buffer, BUFFER_SIZE, stdin);
-        if (strncmp(buffer, "shutdown", 8) == 0) {
-            const char* shutdown_message = "Server is shutting down. Goodbye!\n";
-            broadcast_server_message(shutdown_message);
-            exit(0);
-        } else {
-            broadcast_server_message(buffer);
-        }
-    }
-}
-
 int main() {
     int server_fd;
     int new_socket;
@@ -247,3 +221,31 @@ int setUsername(char* username, struct user* user){
     strcpy(user->username, username);
     return 1;
 }
+
+void *handle_server_commands(void* arg) {
+    char buffer[BUFFER_SIZE];
+    while (1) {
+        fgets(buffer, BUFFER_SIZE, stdin);
+        if (strncmp(buffer, "shutdown", 8) == 0) {
+            const char* shutdown_message = "Server is shutting down. Goodbye!\n";
+            broadcast_server_message(shutdown_message);
+            exit(0);
+        } else {
+            broadcast_server_message(buffer);
+        }
+    }
+}
+
+void broadcast_server_message(const char* message) {
+    pthread_mutex_lock(&clients_mutex);
+
+    for (int i = 0; i < num_clients; i++) {
+        if (send(users[i].clientSocket, message, strlen(message), 0) < 0) {
+            perror("Server broadcast failed");
+        }
+    }
+
+    pthread_mutex_unlock(&clients_mutex);
+}
+
+

--- a/src/main.h
+++ b/src/main.h
@@ -17,8 +17,11 @@ int createServerSocket(int server_fd );
 void setSocketOptions(int socket);
 void setAddressOptions(struct sockaddr_in* address);
 void bindAddressToSocket(int server_fd, struct sockaddr_in* address);
+void setSocketToListen(int server_fd, int totalPendingRequests);
+
 void *handle_client(void *socket_desc);
 void broadcast_message(const char* sender, const char* message, int sender_sock);
-void setSocketToListen(int server_fd, int totalPendingRequests);
+void *handle_server_commands(void* arg);
+void broadcast_server_message(const char* message);
 
 int setUsername(char* username, struct user* user);


### PR DESCRIPTION
Added the functionality that a server also can send a message to all connected client, intended to use as an alert.
Extra: "shutdown" now shuts the server down and sends a goodbye message to all connected clients